### PR TITLE
ci(docs): add debug info for pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,16 +90,11 @@ jobs:
             echo "destination_dir=." >> $GITHUB_OUTPUT
             echo "url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/" >> $GITHUB_OUTPUT
           fi
-
-      - name: Print deployment info
-        run: |
-          echo "Event: ${{ github.event_name }}"
-          echo "Deploying to gh-pages"
       
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
           publish_dir: ./build
           publish_branch: gh-pages
           destination_dir: ${{ steps.vars.outputs.destination_dir }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_PAGES_TOKEN }}
           publish_dir: ./build
           publish_branch: gh-pages
           destination_dir: ${{ steps.vars.outputs.destination_dir }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,11 @@ jobs:
             echo "url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/" >> $GITHUB_OUTPUT
           fi
 
+      - name: Print deployment info
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "Deploying to gh-pages"
+      
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
**Description**

This pr improves the ci preview workflow by validating the deployment flow of the github pages.A small debug step was added to confirm when the deploy job is reached.During investigation,it was verified that the ci build and deploy work correctly.The previous lack of preview wasn't because of the deploy logic but by github pages being disabled. This PR helps make the deployment behavior easier to debug.

**Type of change**

☑️ Bug fix 

☑️ Documentation / CI-related update

**Checklist**

☑️ I have performed a self-review of my own changes.

☑️ The changes are minimal and non-intrusive.

☑️ The CI workflow behavior was validated on a fork.

☑️ The docs preview was verified to work once GitHub Pages is enabled.

☑️ No existing functionality is modified or broken.

☑️ No additional warnings are introduced.